### PR TITLE
Fix dispatching of MAP_LOADED action type, re-load map only when necessary, fix LoadScreen props

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -84,7 +84,7 @@ const App = props => {
     (config.portalUrl && !user) ||
     (signInRequested && !user)
   ) {
-    return <LoadScreen isLoaded={false} />;
+    return <LoadScreen isLoading={true} />;
   }
 
   // App is initialized and user is authenticated if needed, route to main component

--- a/src/components/esri/map/Map.js
+++ b/src/components/esri/map/Map.js
@@ -20,13 +20,13 @@
 
 // React imports
 import React, { useEffect } from "react";
+import { useDispatch } from "react-redux";
 
 // ESRI ArcGIS API
 import { loadMap } from "../../../utils/map";
 
 // Styled Components
 import styled from "styled-components";
-import { useDispatch } from "react-redux";
 
 const Container = styled.div`
   height: 100%;

--- a/src/components/esri/map/Map.js
+++ b/src/components/esri/map/Map.js
@@ -34,18 +34,18 @@ const Container = styled.div`
 `;
 
 // Component
-const Map = props => {
+const Map = ({mapConfig, onMapLoaded}) => {
   // set an ID for the map to attach to
   const containerID = "map-view-container";
   const dispatch = useDispatch();
 
   useEffect(() => {
     // load map with config properties
-    loadMap(containerID, props.mapConfig).then(() => {
+    loadMap(containerID, mapConfig).then(() => {
       // dispatch the map loaded event when we get the map view back
-      dispatch(props.onMapLoaded());
+      dispatch(onMapLoaded());
     });
-  }, [loadMap, containerID, props.mapConfig, dispatch, props.onMapLoaded])
+  }, [containerID, dispatch, mapConfig, onMapLoaded])
 
   // Component template
   return <Container id={containerID}></Container>;

--- a/src/components/esri/map/Map.js
+++ b/src/components/esri/map/Map.js
@@ -19,13 +19,14 @@
 // by listening for any new props (using componentWillReceiveProps)
 
 // React imports
-import React from "react";
+import React, { useEffect } from "react";
 
 // ESRI ArcGIS API
 import { loadMap } from "../../../utils/map";
 
 // Styled Components
 import styled from "styled-components";
+import { useDispatch } from "react-redux";
 
 const Container = styled.div`
   height: 100%;
@@ -36,14 +37,17 @@ const Container = styled.div`
 const Map = props => {
   // set an ID for the map to attach to
   const containerID = "map-view-container";
+  const dispatch = useDispatch();
 
-  // load map with config properties
-  loadMap(containerID, props.mapConfig).then(() => {
-    // call the map loaded event when we get the map view back
-    props.onMapLoaded();
-  });
+  useEffect(() => {
+    // load map with config properties
+    loadMap(containerID, props.mapConfig).then(() => {
+      // dispatch the map loaded event when we get the map view back
+      dispatch(props.onMapLoaded());
+    });
+  }, [loadMap, containerID, props.mapConfig, dispatch, props.onMapLoaded])
 
-  // Compnent template
+  // Component template
   return <Container id={containerID}></Container>;
 };
 


### PR DESCRIPTION
This pull request resolves issue #7 

As per title:  

##### In `Map` component:  
1. The `mapLoaded` action was previously called directly to no effect, it is not correctly dispatched to the store.  
1. The `loadMap` call is now wrapped in a useEffect such that it will re-load only if dependencies change rather than on every render.  

##### In `App` component: 
1. Corrected the child `LoadScreen` props